### PR TITLE
Updating typedef to use different export syntax

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ const output = (input, file, format, plugins) => ({
         name: 'sweeplineIntersections',
         file,
         format,
-        exports: 'default'
+        exports: 'named'
     },
     plugins
 })

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ const output = (input, file, format, plugins) => ({
         name: 'sweeplineIntersections',
         file,
         format,
-        exports: 'named'
+        exports: 'default'
     },
     plugins
 })

--- a/src/main.js
+++ b/src/main.js
@@ -4,9 +4,10 @@ import {checkWhichEventIsLeft} from './compareEvents'
 import fillEventQueue from './fillQueue'
 import runCheck from './runCheck'
 
-export default function sweeplineIntersections (geojson, ignoreSelfIntersections) {
+export function sweeplineIntersections (geojson, ignoreSelfIntersections) {
     const eventQueue = new TinyQueue([], checkWhichEventIsLeft)
     fillEventQueue(geojson, eventQueue)
     return runCheck(eventQueue, ignoreSelfIntersections)
 }
 
+export default sweeplineIntersections

--- a/src/main.js
+++ b/src/main.js
@@ -4,10 +4,8 @@ import {checkWhichEventIsLeft} from './compareEvents'
 import fillEventQueue from './fillQueue'
 import runCheck from './runCheck'
 
-export function sweeplineIntersections (geojson, ignoreSelfIntersections) {
+export default function sweeplineIntersections (geojson, ignoreSelfIntersections) {
     const eventQueue = new TinyQueue([], checkWhichEventIsLeft)
     fillEventQueue(geojson, eventQueue)
     return runCheck(eventQueue, ignoreSelfIntersections)
 }
-
-export default sweeplineIntersections

--- a/types.d.ts
+++ b/types.d.ts
@@ -2,7 +2,9 @@ import { FeatureCollection, Feature, GeometryObject } from "geojson";
 
 export type Intersection = [number, number];
 
-export default function sweeplineIntersections(
+export function sweeplineIntersections(
   geojson: FeatureCollection<GeometryObject> | Feature<GeometryObject>,
   ignoreSelfIntersections: boolean
 ): Intersection[];
+
+export default sweeplineIntersections

--- a/types.d.ts
+++ b/types.d.ts
@@ -2,9 +2,9 @@ import { FeatureCollection, Feature, GeometryObject } from "geojson";
 
 export type Intersection = [number, number];
 
-export function sweeplineIntersections(
+declare function sweeplineIntersections(
   geojson: FeatureCollection<GeometryObject> | Feature<GeometryObject>,
   ignoreSelfIntersections: boolean
 ): Intersection[];
 
-export default sweeplineIntersections
+export = sweeplineIntersections;


### PR DESCRIPTION
HI @rowanwins. Would you mind taking a look at this PR? Trying to update Turf to "esm first" packages, and having problems importing sweepline-intersections now that we've got node16 set as the moduleResolution mode.

It might be related to https://github.com/microsoft/TypeScript/issues/50175#issuecomment-1204986989 in that I'm getting the same initial error message when trying to import sweepline-intersections' default export - ```This expression is not callable ... has no call signatures```

Happy to talk through it including any troubleshooting ideas you might have to try first.