### PR TITLE
Fix typescript typings

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,6 +1,12 @@
 import { FeatureCollection, Feature, GeometryObject } from "geojson";
 
-export = function sweeplineIntersections(
+declare namespace sweeplineIntersections {
+  export type Intersection = [number, number];
+}
+
+declare function sweeplineIntersections(
   geojson: FeatureCollection<GeometryObject> | Feature<GeometryObject>,
   ignoreSelfIntersections: boolean
 ): [number, number][];
+
+export = sweeplineIntersections;

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,8 +1,6 @@
 import { FeatureCollection, Feature, GeometryObject } from "geojson";
 
-export type Intersection = [number, number];
-
-export default function sweeplineIntersections(
+export = function sweeplineIntersections(
   geojson: FeatureCollection<GeometryObject> | Feature<GeometryObject>,
   ignoreSelfIntersections: boolean
-): Intersection[];
+): [number, number][];


### PR DESCRIPTION
The typings for `sweepline-intersections` are slightly wrong, and causing issues in Turf.

https://arethetypeswrong.github.io/?p=sweepline-intersections%401.5.0

Rollup is actually using `module.exports = sweeplineIntersections;`, so this changes the types to match that.

You can examine what impact the various changes have by running `npx @arethetypeswrong/cli` and checking out the output, you may will have to build the package first.

In this case, I'm seeing this after making my change:

```
sweepline-intersections v1.5.0

Build tools:
- rollup@^2.7.6
- webpack@^4.29.0

 No problems found 🌟


┌───────────────────┬───────────────────────────┐
│                   │ "sweepline-intersections" │
├───────────────────┼───────────────────────────┤
│ node10            │ 🟢                        │
├───────────────────┼───────────────────────────┤
│ node16 (from CJS) │ 🟢 (CJS)                  │
├───────────────────┼───────────────────────────┤
│ node16 (from ESM) │ 🟢 (CJS)                  │
├───────────────────┼───────────────────────────┤
│ bundler           │ 🟢                        │
└───────────────────┴───────────────────────────┘
```


More information on the exact transformation I made here can be found in the [DefinitelyTyped readme](https://github.com/DefinitelyTyped/DefinitelyTyped?tab=readme-ov-file#arethetypeswrongcli-attw-checks).